### PR TITLE
Allow windows users to pass \t to use as a tab delimiter

### DIFF
--- a/csv.go
+++ b/csv.go
@@ -18,6 +18,24 @@ func containsDelimiter(col string) bool {
 		strings.Contains(col, "^") || strings.Contains(col, "~")
 }
 
+// Parse the delimiter for an escape sequence. This allows windows users to pass
+// in \t since they cannot pass "`t" or "$Tab" to the program.
+func parseDelimiter(delim string, skip bool) string {
+	if !strings.HasPrefix(delim, "\\") || skip {
+		return delim
+	}
+	switch delim {
+	case "\\t":
+		{
+			return "\t"
+		}
+	default:
+		{
+			return delim
+		}
+	}
+}
+
 // Parse columns from first header row or from flags
 func parseColumns(reader *csv.Reader, skipHeader bool, fields string) ([]string, error) {
 	var err error
@@ -109,7 +127,7 @@ func importCSV(filename string, connStr string, schema string, tableName string,
 	defer db.Close()
 
 	var reader *csv.Reader
-	var bar *pb.ProgressBar 
+	var bar *pb.ProgressBar
 	if filename != "" {
 		file, err := os.Open(filename)
 		if err != nil {

--- a/pgfutter.go
+++ b/pgfutter.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -154,6 +155,10 @@ func main() {
 					Value: ",",
 					Usage: "field delimiter",
 				},
+				cli.BoolFlag{
+					Name:  "skip-parse-delimiter",
+					Usage: "skip parsing escape sequences in the given delimiter",
+				},
 			},
 			Action: func(c *cli.Context) {
 				cli.CommandHelpTemplate = strings.Replace(cli.CommandHelpTemplate, "[arguments...]", "<csv-file>", -1)
@@ -166,8 +171,9 @@ func main() {
 
 				skipHeader := c.Bool("skip-header")
 				fields := c.String("fields")
-				delimiter := c.String("delimiter")
-
+				skipParseheader := c.Bool("skip-parse-delimiter")
+				delimiter := parseDelimiter(c.String("delimiter"), skipParseheader)
+				fmt.Println(delimiter)
 				connStr := parseConnStr(c)
 				err := importCSV(filename, connStr, schema, tableName, ignoreErrors, skipHeader, fields, delimiter)
 				exitOnError(err)


### PR DESCRIPTION
If you run pgfutter in windows powershell you cannot pass in "`t" or "$Tab" to the delimiter option for csv imports. With this pull request it now interprets "\t" as a tab character. If the delimiter is not a tab but "\t" you would need to pass in --skip-parse-delimiter. This should solve issue #37.