### PR TITLE
Add null-delimiter for CSV file's parse options.

### DIFF
--- a/import.go
+++ b/import.go
@@ -56,7 +56,15 @@ func newImport(db *sql.DB, schema string, tableName string, columns []string) (*
 	return &Import{txn, stmt}, nil
 }
 
-func (i *Import) AddRow(columns ...interface{}) error {
+func (i *Import) AddRow(nullDelimiter string, columns ...interface{}) error {
+	for index := range columns {
+		column := columns[index]
+
+		if column == nullDelimiter {
+			columns[index] = nil
+		}
+	}
+
 	_, err := i.stmt.Exec(columns...)
 	return err
 }

--- a/json.go
+++ b/json.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -32,7 +31,7 @@ func copyJSONRows(i *Import, reader *bufio.Reader, ignoreErrors bool) (error, in
 		}
 
 		if err != nil {
-			err = errors.New(fmt.Sprintf("%s: %s", err, line))
+			err = fmt.Errorf("%s: %s", err, line)
 			return err, success, failed
 		}
 
@@ -43,7 +42,7 @@ func copyJSONRows(i *Import, reader *bufio.Reader, ignoreErrors bool) (error, in
 				os.Stderr.WriteString(string(line))
 				continue
 			} else {
-				err = errors.New(fmt.Sprintf("%s: %s", err, line))
+				err = fmt.Errorf("%s: %s", err, line)
 				return err, success, failed
 			}
 		}
@@ -55,7 +54,7 @@ func copyJSONRows(i *Import, reader *bufio.Reader, ignoreErrors bool) (error, in
 				os.Stderr.WriteString(string(line))
 				continue
 			} else {
-				err = errors.New(fmt.Sprintf("%s: %s", err, line))
+				err = fmt.Errorf("%s: %s", err, line)
 				return err, success, failed
 			}
 		}
@@ -99,14 +98,14 @@ func importJSON(filename string, connStr string, schema string, tableName string
 
 	if err != nil {
 		lineNumber := success + failed
-		return errors.New(fmt.Sprintf("line %d: %s", lineNumber, err))
-	} else {
-		fmt.Println(fmt.Sprintf("%d rows imported into %s.%s", success, schema, tableName))
-
-		if ignoreErrors && failed > 0 {
-			fmt.Println(fmt.Sprintf("%d rows could not be imported into %s.%s and have been written to stderr.", failed, schema, tableName))
-		}
-
-		return i.Commit()
+		return fmt.Errorf("line %d: %s", lineNumber, err)
 	}
+
+	fmt.Println(fmt.Sprintf("%d rows imported into %s.%s", success, schema, tableName))
+
+	if ignoreErrors && failed > 0 {
+		fmt.Println(fmt.Sprintf("%d rows could not be imported into %s.%s and have been written to stderr.", failed, schema, tableName))
+	}
+
+	return i.Commit()
 }

--- a/pgfutter.go
+++ b/pgfutter.go
@@ -141,6 +141,11 @@ func main() {
 					Value: ",",
 					Usage: "field delimiter",
 				},
+				cli.StringFlag{
+					Name:  "null-delimiter, nd",
+					Value: "\\N",
+					Usage: "null delimiter",
+				},
 				cli.BoolFlag{
 					Name:  "skip-parse-delimiter",
 					Usage: "skip parsing escape sequences in the given delimiter",
@@ -157,11 +162,12 @@ func main() {
 
 				skipHeader := c.Bool("skip-header")
 				fields := c.String("fields")
+				nullDelimiter := c.String("null-delimiter")
 				skipParseheader := c.Bool("skip-parse-delimiter")
 				excel := c.Bool("excel")
 				delimiter := parseDelimiter(c.String("delimiter"), skipParseheader)
 				connStr := parseConnStr(c)
-				err := importCSV(filename, connStr, schema, tableName, ignoreErrors, skipHeader, fields, delimiter, excel)
+				err := importCSV(filename, connStr, schema, tableName, ignoreErrors, skipHeader, fields, delimiter, excel, nullDelimiter)
 				return err
 			},
 		},


### PR DESCRIPTION
Thanks for nice library. I add null-delimiter flag for parsing csv file.
It'll represent `null` value from CSV field to PostgreSQL database.

 - Change `errors.New(fmt.Sprintf(...))` to `fmt.Errorf(...)`
 - Add null-delimiter for check value is null.