### PR TITLE
Fix doc on custom table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ This works the same for invalid JSON objects.
 `pgfutter` will take the sanitized filename as the table name. If you want to specify a custom table name or import into your predefined table schema you can specify the table explicitly.
 
 ```bash
-pgfutter csv --table violations traffic_violations.csv
+pgfutter --table violations csv traffic_violations.csv
 ```
 
 ## Alternatives


### PR DESCRIPTION
The sample command will return:

```
--table doesn't exist as an option
```

Supplying the table flag before the csv call addresses the issue.

Closes #64