### PR TITLE
Fix build becuase urfave/cli had an api change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   directories:
   - samples
 install:
-  - go get github.com/codegangsta/cli
+  - go get github.com/urfave/cli
   - go get github.com/lib/pq
   - go get github.com/kennygrant/sanitize
   - go get github.com/cheggaaa/pb

--- a/pgfutter.go
+++ b/pgfutter.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 )
 
 func exitOnError(err error) {

--- a/postgres.go
+++ b/postgres.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/codegangsta/cli"
+	"github.com/urfave/cli"
 	"github.com/kennygrant/sanitize"
 )
 


### PR DESCRIPTION
The dependency on urfave/cli changed and there is now a v2 of that
module; This code uses v1. The new import url should pull in v1

This branch represents the bare minimum changes required ... I also ran into issues with a few other modules -- I made a go.mod version too - let me know if you'd like a PR from that. :)